### PR TITLE
any: now we are using std::experimental

### DIFF
--- a/include/BackendInterface.h
+++ b/include/BackendInterface.h
@@ -30,9 +30,8 @@
 #ifndef BACKENDINTERFACE_H_20141215
 #define	BACKENDINTERFACE_H_20141215
 
+#include <any.h>
 #include <HandlerInfo.h>
-
-#include <boost/any.hpp>
 
 #include <memory>
 
@@ -53,7 +52,7 @@ public:
    * 
    * @return universal container
    */
-  virtual boost::any retrieve(const std::string& key);
+  virtual universal_retriever::any retrieve(const std::string& key);
 
   /**
    * @brief Stores an object with a given key
@@ -63,7 +62,7 @@ public:
    * @param[in] key key associated with the object
    * @param[in] value object to be stored
    */
-  virtual void store(const std::string& key, const boost::any& value);
+  virtual void store(const std::string& key, const universal_retriever::any& value);
 
   /**
    * @brief Triggers serialization of all the stored objects

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -18,6 +18,7 @@
 #
 
 set(UNIVERSAL_RETRIEVER_INSTALLED_HEADERS
+    ${PROJECT_SOURCE_DIR}/include/any.h
     ${PROJECT_SOURCE_DIR}/include/Frontend.h
     ${PROJECT_SOURCE_DIR}/include/BackendInterface.h
     ${PROJECT_SOURCE_DIR}/include/HandlerInfo.h

--- a/include/Frontend.h
+++ b/include/Frontend.h
@@ -29,12 +29,12 @@
 #ifndef FRONTEND_H_20141215
 #define	FRONTEND_H_20141215
 
+#include <any.h>
 #include <BackendInterface.h>
 
 #include <UniversalRetrieverExceptions.h>
 
 #include <boost/version.hpp>
-#include <boost/any.hpp>
 
 #if BOOST_VERSION > 105500
 #include <boost/type_index.hpp>
@@ -71,8 +71,8 @@ public:
   template<class T>
   T retrieve(const std::string& name, const std::string& key) {
     try {
-      return boost::any_cast<T>(any_retrieve(name, key));
-    } catch (boost::bad_any_cast& e) {
+      return universal_retriever::any_cast<T>(any_retrieve(name, key));
+    } catch (universal_retriever::bad_any_cast& e) {
       std::stringstream estream;
       estream << "ERROR : key \"" << key << "\" in data set \"" << name << "\"";
 #if BOOST_VERSION > 105500
@@ -157,9 +157,9 @@ public:
 
 private:
 
-  boost::any any_retrieve(const std::string& name, const std::string& key);
+  universal_retriever::any any_retrieve(const std::string& name, const std::string& key);
 
-  boost::any any_retrieve_from_hvector(std::vector<HandlerType>& hvector, const std::string& key);
+  universal_retriever::any any_retrieve_from_hvector(std::vector<HandlerType>& hvector, const std::string& key);
 
   std::map< std::string, std::vector<HandlerType> > m_retriever_map;
   std::map< std::string, HandlerType > m_store_map;

--- a/include/any.h
+++ b/include/any.h
@@ -44,6 +44,14 @@ namespace universal_retriever {
     using boost::any_cast;
     using boost::bad_any_cast;
 #endif
+
+    inline bool has_value(const any& value) {
+#if __has_include(<any>) && __cplusplus > 201402L
+        return value.has_value();
+#else
+        return !value.empty();
+#endif
+    }
 }
 
 

--- a/include/any.h
+++ b/include/any.h
@@ -17,16 +17,34 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef UNIVERSALRETRIEVER_ANY_H_20170625
-#define UNIVERSALRETRIEVER_ANY_H_20170625
+#ifndef ANY_H_20170625
+#define ANY_H_20170625
 
+#if __has_include(<any>) && __cplusplus > 201402L
+#include <any>
+#elif __has_include(<experimental/any>) && __cplusplus > 201402L
 #include <experimental/any>
+#elif __has_include(<boost/any.hpp>)
+#include <boost/any.hpp>
+#else
+#error "Found no implementation of 'any' class."
+#endif
 
 namespace universal_retriever {
+#if __has_include(<any>) && __cplusplus > 201402L
+    using std::any;
+    using std::any_cast;
+    using std::bad_any_cast;
+#elif __has_include(<experimental/any>) && __cplusplus > 201402L
     using std::experimental::any;
     using std::experimental::any_cast;
     using std::experimental::bad_any_cast;
+#elif __has_include(<boost/any.hpp>)
+    using boost::any;
+    using boost::any_cast;
+    using boost::bad_any_cast;
+#endif
 }
 
 
-#endif //UNIVERSALRETRIEVER_ANY_H_20170625
+#endif //ANY_H_20170625

--- a/include/any.h
+++ b/include/any.h
@@ -1,6 +1,6 @@
 /*
  *  Universal Retriever : flexible engine for the retrieval of persistent objects
- * 
+ *
  *  Copyright (C) 2014  Massimiliano Culpo
  *
  *  Universal Retriever is free software: you can redistribute it and/or modify
@@ -17,40 +17,16 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * @file SimpleBackend.h
- * 
- * @brief A simple back-end for unit test purposes
- * 
- * @author Massimiliano Culpo
- *
- * Created on December 17, 2014, 8:07 PM
- */
+#ifndef UNIVERSALRETRIEVER_ANY_H_20170625
+#define UNIVERSALRETRIEVER_ANY_H_20170625
 
-#ifndef SIMPLE_BACKEND_H_20141217
-#define	SIMPLE_BACKEND_H_20141217
-
-#include <BackendInterface.h>
+#include <experimental/any>
 
 namespace universal_retriever {
-
-class SimpleBackEnd : public BackendInterface {
-public:
-
-  universal_retriever::any retrieve(const std::string& key) final;
-
-  HandlerInfo info() final;
-
-  void store(const std::string& key, const universal_retriever::any& value) final;
-
-private:
-  int m_integer = 10;
-  double m_double = 0.0;
-  
-  REGISTRABLE_BACKEND;
-};
-
+    using std::experimental::any;
+    using std::experimental::any_cast;
+    using std::experimental::bad_any_cast;
 }
 
-#endif	/* SIMPLE_BACKEND_H_20141217 */
 
+#endif //UNIVERSALRETRIEVER_ANY_H_20170625

--- a/src/BackendInterface.cpp
+++ b/src/BackendInterface.cpp
@@ -34,12 +34,12 @@ using namespace std;
 
 namespace universal_retriever {
 
-boost::any BackendInterface::retrieve(const std::string& key)
+universal_retriever::any BackendInterface::retrieve(const std::string& key)
 {
-  return boost::any();
+  return universal_retriever::any();
 }
 
-void BackendInterface::store(const std::string& key, const boost::any& value)
+void BackendInterface::store(const std::string& key, const universal_retriever::any& value)
 {
   stringstream estream;
   estream << "ERROR : the store cannot be performed as " << __func__ << "was not overridden" << endl;

--- a/src/Frontend.cpp
+++ b/src/Frontend.cpp
@@ -138,7 +138,7 @@ void Frontend::serialize(const std::string& name)
 // Private
 //
 
-boost::any Frontend::any_retrieve(const std::string& name, const std::string& key)
+universal_retriever::any Frontend::any_retrieve(const std::string& name, const std::string& key)
 {
   try
   {
@@ -154,7 +154,7 @@ boost::any Frontend::any_retrieve(const std::string& name, const std::string& ke
   }
 }
 
-boost::any Frontend::any_retrieve_from_hvector(std::vector<HandlerType>& hvector, const std::string& key)
+universal_retriever::any Frontend::any_retrieve_from_hvector(std::vector<HandlerType>& hvector, const std::string& key)
 {
   for (auto& x : hvector)
   {

--- a/src/Frontend.cpp
+++ b/src/Frontend.cpp
@@ -159,7 +159,7 @@ universal_retriever::any Frontend::any_retrieve_from_hvector(std::vector<Handler
   for (auto& x : hvector)
   {
     auto value = x->retrieve(key);
-    if (!value.empty()) return value;
+    if ( has_value(value) ) return value;
   }
   // If the function did not return, then throw an exception
   stringstream estream;

--- a/test/SimpleBackend.cpp
+++ b/test/SimpleBackend.cpp
@@ -29,16 +29,11 @@
 
 #include <SimpleBackend.h>
 
-#include <boost/any.hpp>
-
-#include <memory>
-#include <stdexcept>
-
 using namespace std;
 
 namespace universal_retriever {
 
-boost::any SimpleBackEnd::retrieve(const std::string& key)
+universal_retriever::any SimpleBackEnd::retrieve(const std::string& key)
 {
   if (key == "integer")
   {
@@ -48,7 +43,7 @@ boost::any SimpleBackEnd::retrieve(const std::string& key)
   {
     return m_double;
   }
-  return boost::any();
+  return universal_retriever::any();
 }
 
 HandlerInfo SimpleBackEnd::info()
@@ -56,15 +51,15 @@ HandlerInfo SimpleBackEnd::info()
   return HandlerInfo("simple_backend", "1.0", "memory");
 }
 
-void SimpleBackEnd::store(const std::string& key, const boost::any& value)
+void SimpleBackEnd::store(const std::string& key, const universal_retriever::any& value)
 {
   if (key == "integer")
   {
-    m_integer=boost::any_cast<int>(value);
+    m_integer = universal_retriever::any_cast<int>(value);
   }
   else if (key == "double")
   {
-    m_double=boost::any_cast<double>(value);
+    m_double = universal_retriever::any_cast<double>(value);
   }
   else
   {


### PR DESCRIPTION
BoostAny has been replaced by std::any where available. Also adding a new header to select an implementation of any for the whole namespace.